### PR TITLE
Make cache sizes configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Set the following environment variables:
 - `DISABLE_SPEEDTEST`: Optional. Disables the speedtest UI. Returns 404 for the /speedtest path and direct access to speedtest.html. Default is `false`.
 - `STREMIO_PROXY_URL`: Optional. Stremio server URL for alternative content proxying. Example: `http://127.0.0.1:11470`.
 - `M3U8_CONTENT_ROUTING`: Optional. Routing strategy for M3U8 content URLs: `mediaflow` (default), `stremio`, or `direct`.
+- `INIT_SEGMENT_CACHE_SIZE_MB`: Optional. Size of the init segment cache in MB. Default is `500`.
+- `MPD_CACHE_SIZE_MB`: Optional. Size of the MPD cache in MB. Default is `100`.
+- `EXTRACTOR_CACHE_SIZE_MB`: Optional. Size of the extractor cache in MB. Default is `50`.
 
 ### Transport Configuration
 

--- a/mediaflow_proxy/configs.py
+++ b/mediaflow_proxy/configs.py
@@ -68,6 +68,11 @@ class Settings(BaseSettings):
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"  # The user agent to use for HTTP requests.
     )
 
+    # Cache configuration (sizes in MB)
+    init_segment_cache_size_mb: int = 500  # Size of the init segment cache in MB
+    mpd_cache_size_mb: int = 100  # Size of the MPD cache in MB
+    extractor_cache_size_mb: int = 50  # Size of the extractor cache in MB
+
     class Config:
         env_file = ".env"
         extra = "ignore"

--- a/mediaflow_proxy/utils/cache_utils.py
+++ b/mediaflow_proxy/utils/cache_utils.py
@@ -17,6 +17,7 @@ import aiofiles.os
 
 from mediaflow_proxy.utils.http_utils import download_file_with_retry, DownloadError
 from mediaflow_proxy.utils.mpd_utils import parse_mpd, parse_mpd_dict
+from mediaflow_proxy.configs import settings
 
 logger = logging.getLogger(__name__)
 
@@ -261,17 +262,17 @@ class AsyncMemoryCache:
 INIT_SEGMENT_CACHE = HybridCache(
     cache_dir_name="init_segment_cache",
     ttl=3600,  # 1 hour
-    max_memory_size=500 * 1024 * 1024,  # 500MB for init segments
+    max_memory_size=settings.init_segment_cache_size_mb * 1024 * 1024,
 )
 
 MPD_CACHE = AsyncMemoryCache(
-    max_memory_size=100 * 1024 * 1024,  # 100MB for MPD files
+    max_memory_size=settings.mpd_cache_size_mb * 1024 * 1024,
 )
 
 EXTRACTOR_CACHE = HybridCache(
     cache_dir_name="extractor_cache",
     ttl=5 * 60,  # 5 minutes
-    max_memory_size=50 * 1024 * 1024,
+    max_memory_size=settings.extractor_cache_size_mb * 1024 * 1024,
 )
 
 


### PR DESCRIPTION
## Summary
- support env vars to configure HybridCache and AsyncMemoryCache sizes
- pass these variables into the caches
- document cache configuration in README

## Testing
- `pytest -q`
- `python -m py_compile mediaflow_proxy/configs.py mediaflow_proxy/utils/cache_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68689d6b5838832e9b9dc29dc90eaa90